### PR TITLE
Use config file for required value

### DIFF
--- a/cmd/cluster_delete.go
+++ b/cmd/cluster_delete.go
@@ -26,6 +26,7 @@ import (
 
 	pb "github.com/openinfradev/tks-proto/tks_pb"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -45,7 +46,12 @@ tks cluster delete <CLUSTER_ID>`,
 		}
 
 		var conn *grpc.ClientConn
-		conn, err := grpc.Dial(address, grpc.WithInsecure())
+		tksClusterLcmUrl = viper.GetString("tksClusterLcmUrl")
+		if tksClusterLcmUrl == "" {
+			fmt.Println("You must specify tksClusterLcmUrl at config file")
+			os.Exit(1)
+		}
+		conn, err := grpc.Dial(tksClusterLcmUrl, grpc.WithInsecure())
 		if err != nil {
 			log.Fatalf("did not connect: %s", err)
 		}

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -26,6 +27,7 @@ import (
 	"github.com/jedib0t/go-pretty/table"
 	pb "github.com/openinfradev/tks-proto/tks_pb"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -39,8 +41,12 @@ var clusterListCmd = &cobra.Command{
 Example:
 tks cluster list (--long)`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("list called")
 		var conn *grpc.ClientConn
+		tksInfoUrl = viper.GetString("tksInfoUrl")
+		if tksInfoUrl == "" {
+			fmt.Println("You must specify tksInfoUrl at config file")
+			os.Exit(1)
+		}
 		conn, err := grpc.Dial(tksInfoUrl, grpc.WithInsecure())
 		if err != nil {
 			log.Fatalf("did not connect: %s", err)
@@ -51,7 +57,11 @@ tks cluster list (--long)`,
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 		data := pb.GetClustersRequest{}
-		data.ContractId = defaultContractId
+		data.ContractId = viper.GetString("contractId")
+		if data.ContractId == "" {
+			fmt.Println("You must specify contractId at config file")
+			os.Exit(1)
+		}
 
 		m := protojson.MarshalOptions{
 			Indent:        "  ",

--- a/cmd/cluster_show.go
+++ b/cmd/cluster_show.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jedib0t/go-pretty/table"
 	pb "github.com/openinfradev/tks-proto/tks_pb"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -44,6 +45,11 @@ tks cluster show <CLUSTER_ID>`,
 			os.Exit(1)
 		}
 		var conn *grpc.ClientConn
+		tksInfoUrl = viper.GetString("tksInfoUrl")
+		if tksInfoUrl == "" {
+			fmt.Println("You must specify tksInfoUrl at config file")
+			os.Exit(1)
+		}
 		conn, err := grpc.Dial(tksInfoUrl, grpc.WithInsecure())
 		if err != nil {
 			log.Fatalf("did not connect: %s", err)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -15,10 +15,10 @@ limitations under the License.
 */
 package cmd
 
-const (
-	defaultContractId string = "f84df193-f6c8-45ad-867c-c0bcc48f09e5"
-	defaultCspId      string = "c947d800-ac43-4bab-a8e1-4ceaa0ffec98"
-	tksInfoUrl               = "tks-info.taco-cat.xyz:9110"
-	tksClusterLcmUrl         = "tks-cluster-lcm.taco-cat.xyz:9110"
-	tksContractUrl           = "tks-contract.taco-cat.xyz:9110"
+var (
+	defaultContractId string
+	defaultCspId      string
+	tksInfoUrl        string
+	tksClusterLcmUrl  string
+	tksContractUrl    string
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 

--- a/cmd/service_create.go
+++ b/cmd/service_create.go
@@ -27,6 +27,7 @@ import (
 
 	pb "github.com/openinfradev/tks-proto/tks_pb"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -55,6 +56,11 @@ tks service create --cluster-id <CLUSTERID> --service-name <LMA,LMA_EFK,SERVICE_
 		}
 
 		var conn *grpc.ClientConn
+		tksClusterLcmUrl = viper.GetString("tksClusterLcmUrl")
+		if tksClusterLcmUrl == "" {
+			fmt.Println("You must specify tksClusterLcmUrl at config file")
+			os.Exit(1)
+		}
 		conn, err := grpc.Dial(tksClusterLcmUrl, grpc.WithInsecure())
 		if err != nil {
 			log.Fatalf("did not connect: %s", err)


### PR DESCRIPTION
tks 환경마다 달라지는 값을 클라이언트 설정을 통해 사용하도록 변경하였습니다.
환경파일 위치: ~/.tks-client.yaml
환경파일 내용
```
contractId: f84df193-f6c8-45ad-867c-c0bcc48f09e5
cspId: c947d800-ac43-4bab-a8e1-4ceaa0ffec98
tksInfoUrl: "tks-info.taco-cat.xyz:9110"
tksClusterLcmUrl: "tks-cluster-lcm.taco-cat.xyz:9110"
tksContractUrl: "tks-contract.taco-cat.xyz:9110"

```

위 내용이 불충족하면 cli 실행 시 관련 에러가 발생합니다.