### PR TITLE
Delete part of check ContracdId, CspId

### DIFF
--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -41,7 +41,7 @@ tks cluster create <CLUSTERNAME>`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			fmt.Println("You must specify cluster name.")
-			fmt.Println("Usage: tks cluster create <CLUSTERNAME> --contract-id <CONTRACTID> --csp-id <CSPID>")
+			fmt.Println("Usage: tks cluster create <CLUSTERNAME>")
 			os.Exit(1)
 		}
 		var conn *grpc.ClientConn
@@ -63,21 +63,7 @@ tks cluster create <CLUSTERNAME>`,
 		/* Parse command line arguments */
 		ClusterName := args[0]
 		ContractId, _ := cmd.Flags().GetString("contract-id")
-		if ContractId == "" {
-			ContractId = viper.GetString("contractId")
-			if ContractId == "" {
-				fmt.Println("You must specify contractId and cspId")
-				os.Exit(1)
-			}
-		}
 		CspId, _ := cmd.Flags().GetString("csp-id")
-		if CspId == "" {
-			CspId = viper.GetString("cspId")
-			if CspId == "" {
-				fmt.Println("You must specify contractId and cspId")
-				os.Exit(1)
-			}
-		}
 		conf := pb.ClusterRawConf{}
 		conf.SshKeyName, _ = cmd.Flags().GetString("ssh-key-name")
 		conf.Region, _ = cmd.Flags().GetString("region")

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -58,10 +58,6 @@ tks cluster list (--long)`,
 		defer cancel()
 		data := pb.GetClustersRequest{}
 		data.ContractId = viper.GetString("contractId")
-		if data.ContractId == "" {
-			fmt.Println("You must specify contractId at config file")
-			os.Exit(1)
-		}
 
 		m := protojson.MarshalOptions{
 			Indent:        "  ",


### PR DESCRIPTION
- tks api service에서 default contractId와 cspId를 체크하는 로직이 추가됨에 따라, client에서 해당 변수를 사용하지 않아도 되기에 관련부분을 삭제합니다.
- 테스트 방법: 
```
$ task build
$ bin/tks cluster list
$ bin/tks cluster craete <cluster name>
``` 