### PR TITLE
handle case that GetClusters returns empty list

### DIFF
--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -74,7 +74,11 @@ tks cluster list (--long)`,
 		if err != nil {
 			fmt.Println(err)
 		} else {
-			printClusters(filterResponse(r), long)
+			if len(r.Clusters) == 0 {
+				fmt.Println("No cluster exists for specified contract!")
+			} else {
+				printClusters(filterResponse(r), long)
+			}
 		}
 	},
 }
@@ -127,7 +131,7 @@ func parseTime(t *timestamppb.Timestamp) string {
 }
 
 func filterResponse(r *pb.GetClustersResponse) *pb.GetClustersResponse {
-	clusters := []*pb.Cluster {}
+	clusters := []*pb.Cluster{}
 	for _, cluster := range r.Clusters {
 		if cluster.GetStatus() != pb.ClusterStatus_DELETED {
 			clusters = append(clusters, cluster)


### PR DESCRIPTION
금일 테스트 중 발견된 이슈에 대한 버그 픽스입니다.
 - 이슈: "tks cluster list" 명령 수행시 cluster 가 존재하지 않을 경우 에러 메세지 출력됨.
 - 수정사항: cluster 존재하지 않을 경우에도 유효한 결과로 처리

태규님이 올리신 https://github.com/openinfradev/tks-info/pull/41 에 tks-info 쪽 수정사항 커밋하였습니다.
https://github.com/openinfradev/tks-info/pull/41/commits/1d03d9c8723875eced4e400d5dda7156310d2c0b