### PR TITLE
bugfix: show error info when request fails

### DIFF
--- a/cmd/service_create.go
+++ b/cmd/service_create.go
@@ -95,8 +95,14 @@ tks service create --cluster-id <CLUSTERID> --service-name <LMA,LMA_EFK,SERVICE_
 		jsonBytes, _ := m.Marshal(&data[0])
 		fmt.Println("Proto Json data...")
 		fmt.Println(string(jsonBytes))
+
 		r, err := client.InstallAppGroups(ctx, &data[0])
-		fmt.Println(r)
+		fmt.Println("Response:\n", r)
+		if err != nil {
+			fmt.Println("Error:", err)
+		} else {
+			fmt.Println("Success: The request to create service ", args[0], " was accepted.")
+		}
 	},
 }
 


### PR DESCRIPTION
service create 명령이 실패할 경우 에러 정보 보여주는 부분이 누락되어 있어 추가합니다.