### PR TITLE
Remove os.Exit for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.so
 *.dylib
 bin/
-
+.vscode/
 # Test binary, built with `go test -c`
 *.test
 

--- a/cmd/cluster_create.go
+++ b/cmd/cluster_create.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -38,17 +38,16 @@ var clusterCreateCmd = &cobra.Command{
   
 Example:
 tks cluster create <CLUSTERNAME>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error{
 		if len(args) == 0 {
 			fmt.Println("You must specify cluster name.")
-			fmt.Println("Usage: tks cluster create <CLUSTERNAME>")
-			os.Exit(1)
+			return errors.New("Usage: tks cluster create <CLUSTERNAME>")
 		}
 		var conn *grpc.ClientConn
 		tksClusterLcmUrl = viper.GetString("tksClusterLcmUrl")
 		if tksClusterLcmUrl == "" {
-			fmt.Println("You must specify tksClusterLcmUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksClusterLcmUrl at config file")
 		}
 		conn, err := grpc.Dial(tksClusterLcmUrl, grpc.WithInsecure())
 		if err != nil {
@@ -98,6 +97,8 @@ tks cluster create <CLUSTERNAME>`,
 		} else {
 			fmt.Println("Success: The request to create cluster ", args[0], " was accepted.")
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/cluster_delete.go
+++ b/cmd/cluster_delete.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -38,18 +38,18 @@ var clusterDeleteCmd = &cobra.Command{
 	
 Example:
 tks cluster delete <CLUSTER_ID>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			fmt.Println("You must specify cluster name.")
-			fmt.Println("Usage: tks cluster delete <CLUSTER_ID>")
-			os.Exit(1)
+			return errors.New("Usage: tks cluster delete <CLUSTER_ID>")
 		}
 
 		var conn *grpc.ClientConn
 		tksClusterLcmUrl = viper.GetString("tksClusterLcmUrl")
 		if tksClusterLcmUrl == "" {
 			fmt.Println("You must specify tksClusterLcmUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksClusterLcmUrl at config file")
 		}
 		conn, err := grpc.Dial(tksClusterLcmUrl, grpc.WithInsecure())
 		if err != nil {
@@ -79,6 +79,7 @@ tks cluster delete <CLUSTER_ID>`,
 		} else {
 			fmt.Println("The request to delete cluster ", args[0], " was accepted.")
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -40,12 +40,12 @@ var clusterListCmd = &cobra.Command{
 
 Example:
 tks cluster list (--long)`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var conn *grpc.ClientConn
 		tksInfoUrl = viper.GetString("tksInfoUrl")
 		if tksInfoUrl == "" {
-			fmt.Println("You must specify tksInfoUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksInfoUrl at config file")
 		}
 		conn, err := grpc.Dial(tksInfoUrl, grpc.WithInsecure())
 		if err != nil {
@@ -80,6 +80,7 @@ tks cluster list (--long)`,
 				printClusters(filterResponse(r), long)
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/cluster_show.go
+++ b/cmd/cluster_show.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/jedib0t/go-pretty/table"
@@ -38,17 +38,16 @@ var clusterShowCmd = &cobra.Command{
 
 Example:
 tks cluster show <CLUSTER_ID>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			fmt.Println("You must specify cluster id.")
-			fmt.Println("Usage: tks cluster show <CLUSTER_ID>")
-			os.Exit(1)
+			return errors.New("Usage: tks cluster show <CLUSTER_ID>")
 		}
 		var conn *grpc.ClientConn
 		tksInfoUrl = viper.GetString("tksInfoUrl")
 		if tksInfoUrl == "" {
-			fmt.Println("You must specify tksInfoUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksInfoUrl at config file")
 		}
 		conn, err := grpc.Dial(tksInfoUrl, grpc.WithInsecure())
 		if err != nil {
@@ -78,6 +77,7 @@ tks cluster show <CLUSTER_ID>`,
 		} else {
 			printCluster(r)
 		}
+		return nil
 	},
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -91,9 +91,9 @@ func TestClusterCmd(t *testing.T) {
 
 		{[]string{"cluster"}, true, "", ""},
 		{[]string{"cluster", "wrong"}, true, "", ""},
-		// {[]string{"cluster", "create"}, true, "required flag(s) \"contract-id\", \"csp-id\" not set", ""}, 	// It generates Exit(1) and the FAILed test
+		{[]string{"cluster", "create"}, true, "Usage: tks cluster create <CLUSTERNAME>", ""},
 		{[]string{"cluster", "create", "--config"}, true, "flag needs an argument: --config", ""},
-		// {[]string{"cluster", "create", "--config", "xx"}, true, "required flag(s) \"contract-id\", \"csp-id\" not set", ""}, 	// It generates Exit(1) and the FAILed test
+		{[]string{"cluster", "create", "--config", "xx"}, true, "Usage: tks cluster create <CLUSTERNAME>", ""},
 		{[]string{"cluster", "create", "-h"}, false, "", "Create a TKS Cluster to AWS."},
 		{[]string{"cluster", "create", "--contract-id"}, true, "flag needs an argument: --contract-id", ""},
 		{[]string{"cluster", "create", "--contract-id", "1234"}, false, "", ""},
@@ -104,9 +104,9 @@ func TestClusterCmd(t *testing.T) {
 		{[]string{"cluster", "create", "--contract-id", "--csp-id", "2345234", "hihi", "--config"}, true, "flag needs an argument: --config", ""},
 		{[]string{"cluster", "create", "--contract-id", "abcd-efg", "--csp-id", "2345234", "hihi"}, false, "", "Create a TKS Cluster to AWS"},
 
-		// {[]string{"cluster", "list"}, true, "", ""},	// It generates Exit(1) and the FAILed test
+		{[]string{"cluster", "list"}, true, "", ""},
 		{[]string{"cluster", "list", "-h"}, false, "", "A longer description that spans multiple lines and likely contains examples"},
-		{[]string{"cluster", "list", "--config", "xx"}, false, "", "A longer description that spans multiple lines and likely contains examples"}, // It generates Exit(1) and the FAILed test
+		{[]string{"cluster", "list", "--config", "xx"}, false, "", "A longer description that spans multiple lines and likely contains examples"},
 		{[]string{"cluster", "list", "--config"}, true, "flag needs an argument: --config", ""},
 	}
 
@@ -120,9 +120,9 @@ func TestServiceCmd(t *testing.T) {
 		{[]string{"service", "-h"}, false, "", ""},
 		{[]string{"service", "create"}, true, "required flag(s) \"cluster-id\", \"service-name\" not set", ""},
 		{[]string{"service", "create", "--cluster-id"}, true, "flag needs an argument: --cluster-id", ""},
-		// {[]string{"service", "create", "--cluster-id", "--service-name"}, true, "required flag(s) \"service-name\" not set"), ""},
-		// {[]string{"service", "create", "--cluster-id", "aaa", "--service-name"}, true, "flag needs an argument: --service-name"), ""},
-		// {[]string{"service", "create", "--cluster-id", "aaa", "--service-name", "LMA"}, true, "", ""}, // It generates Exit(1) and the FAILed test
+		{[]string{"service", "create", "--cluster-id", "--service-name"}, true, "required flag(s) \"service-name\" not set", ""},
+		{[]string{"service", "create", "--cluster-id", "aaa", "--service-name"}, true, "flag needs an argument: --service-name", ""},
+		{[]string{"service", "create", "--cluster-id", "aaa", "--service-name", "LMA"}, true, "", ""},
 	}
 
 	doTest(t, testcases)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ For more: https://github.com/openinfradev/tks-client/`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
+	rootCmd.Execute()
 }
 
 func init() {

--- a/cmd/service_create.go
+++ b/cmd/service_create.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"time"
 
@@ -40,7 +40,8 @@ var serviceCreateCmd = &cobra.Command{
 
 Example:
 tks service create --cluster-id <CLUSTERID> --service-name <LMA,LMA_EFK,SERVICE_MESH>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("create called")
 		ServiceName, _ := cmd.Flags().GetString("service-name")
 		var Type pb.AppGroupType
@@ -51,15 +52,13 @@ tks service create --cluster-id <CLUSTERID> --service-name <LMA,LMA_EFK,SERVICE_
 		} else if ServiceName == "SERVICE_MESH" {
 			Type = pb.AppGroupType_SERVICE_MESH
 		} else {
-			fmt.Println("You must specify Service Name. LMA | LMA_EFK | SERVICE_MESH")
-			os.Exit(1)
+			return errors.New("You must specify Service Name. LMA | LMA_EFK | SERVICE_MESH")
 		}
 
 		var conn *grpc.ClientConn
 		tksClusterLcmUrl = viper.GetString("tksClusterLcmUrl")
 		if tksClusterLcmUrl == "" {
-			fmt.Println("You must specify tksClusterLcmUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksClusterLcmUrl at config file")
 		}
 		conn, err := grpc.Dial(tksClusterLcmUrl, grpc.WithInsecure())
 		if err != nil {
@@ -103,6 +102,7 @@ tks service create --cluster-id <CLUSTERID> --service-name <LMA,LMA_EFK,SERVICE_
 		} else {
 			fmt.Println("Success: The request to create service ", AppGroupName, " was accepted.")
 		}
+		return nil
 	},
 }
 

--- a/cmd/service_delete.go
+++ b/cmd/service_delete.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -38,17 +38,16 @@ var serviceDeleteCmd = &cobra.Command{
 
 Example:
 tks service delete <SERVICE ID>`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			fmt.Println("You must specify service ID.")
-			fmt.Println("Usage: tks service delete <SERVICE ID>")
-			os.Exit(1)
+			return errors.New("Usage: tks service delete <SERVICE ID>")
 		}
 		var conn *grpc.ClientConn
 		tksClusterLcmUrl = viper.GetString("tksClusterLcmUrl")
 		if tksClusterLcmUrl == "" {
-			fmt.Println("You must specify tksClusterLcmUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksClusterLcmUrl at config file")
 		}
 		conn, err := grpc.Dial(tksClusterLcmUrl, grpc.WithInsecure())
 		if err != nil {
@@ -81,6 +80,7 @@ tks service delete <SERVICE ID>`,
 		} else {
 			fmt.Println(r)
 		}
+		return nil
 	},
 }
 

--- a/cmd/service_list.go
+++ b/cmd/service_list.go
@@ -17,9 +17,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -39,17 +39,16 @@ var serviceListCmd = &cobra.Command{
 
 Example:
 tks service list <CLUSTER ID> (--long)`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			fmt.Println("You must specify cluster ID.")
-			fmt.Println("Usage: tks service list <CLUSTER ID>")
-			os.Exit(1)
+			return errors.New("Usage: tks service list <CLUSTER ID>")
 		}
 		var conn *grpc.ClientConn
 		tksInfoUrl = viper.GetString("tksInfoUrl")
 		if tksInfoUrl == "" {
-			fmt.Println("You must specify tksInfoUrl at config file")
-			os.Exit(1)
+			return errors.New("You must specify tksInfoUrl at config file")
 		}
 		conn, err := grpc.Dial(tksInfoUrl, grpc.WithInsecure())
 		if err != nil {
@@ -83,6 +82,7 @@ tks service list <CLUSTER ID> (--long)`,
 			long, _ := cmd.Flags().GetBool("long")
 			printAppGroups(r, long)
 		}
+		return nil
 	},
 }
 


### PR DESCRIPTION
기존 소스코드에서 잘못된 Argument 발견시 즉시 종료를 위해 사용한 `os.Exit(1)`이 unit test시 이 후 테스트를 수행하지 못하고 바로 종료되는 버그가 존재하여 `os.Exit(1)`이 아닌 errors객체를 사용하도록 변경한 PR입니다.
