### PR TITLE
feature. add contractId to "cluster list" command.

### DIFF
--- a/cmd/cluster_list.go
+++ b/cmd/cluster_list.go
@@ -40,7 +40,7 @@ var clusterListCmd = &cobra.Command{
 	Long: `Show list of clusters.
 
 Example:
-tks cluster list (--long)`,
+tks cluster list <CONTRACT_ID> (--long)`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var conn *grpc.ClientConn
@@ -58,7 +58,12 @@ tks cluster list (--long)`,
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 		data := pb.GetClustersRequest{}
-		data.ContractId = viper.GetString("contractId")
+
+		if len(args) > 0 && args[0] != "" {
+			data.ContractId = args[0]
+		} else {
+			data.ContractId = viper.GetString("contractId")
+		}
 
 		m := protojson.MarshalOptions{
 			Indent:        "  ",


### PR DESCRIPTION
tks-cli 로 cluster list 조회시 contractId 를 지정할 수 없습니다.
contractId 를 지정하도록 변경합니다.
